### PR TITLE
fix typos in tutorials

### DIFF
--- a/tutorials/ioth.md
+++ b/tutorials/ioth.md
@@ -31,6 +31,6 @@ IoTh instead has a completely opposite approach, each process can use one or mor
 network stacks implemented as libraries, users can own and manage their virtual networks.
 
 Note: ![wip](pictures/wip.png) we are working to support user-level stacks. We are porting
-[picotcp-ng](https://gitlab.com/insane-adding-machines/picotcp) and evaluating
+[picotcp-ng](https://github.com/virtualsquare/picotcp) and evaluating
 [lwip](https://savannah.nongnu.org/projects/lwip/) and our old
-[lwipv6](http://wiki.v2.cs.unibo.it/wiki/index.php?title=LWIPV6)
+[lwipv6](https://github.com/virtualsquare/view-os/tree/master/lwipv6)

--- a/tutorials/setup_the_vm.md
+++ b/tutorials/setup_the_vm.md
@@ -20,7 +20,7 @@ It is approximately 0.45GB.
 ## step 2: uncompress the image:
 
 ```bash
-$ bunzip2 debian-sid-v2-amd64-daily-????????-???.qcow2.bz2
+$ bunzip2 debian-sid-v2-amd64-daily-????????-????.qcow2.bz2
 ```
 
 question marks should be changed with the actual date and version number of the disk image.
@@ -38,7 +38,7 @@ We suggest the following command:
 ``` bash
 $ qemu-system-x86_64 -enable-kvm -smp $(nproc) -m 2G -monitor stdio -cpu host\
     -netdev type=user,id=net,hostfwd=tcp::2222-:22 -device virtio-net-pci,netdev=net \
-    -drive file=$(echo debian-sid-v2-amd64-daily-????????-???.qcow2)
+    -drive file=$(echo debian-sid-v2-amd64-daily-????????-????.qcow2)
 ```
 
 The number of cores (``-smp $(nproc)``) and the amount of memory (``-m 2G``) should be adapted to 

--- a/tutorials/vde_ns.md
+++ b/tutorials/vde_ns.md
@@ -124,7 +124,7 @@ As one may expect the number of the controller reflects the sequence of argument
 ## vdens-multi as VDE router (NFV)
 
 The following example uses a `vdens` as a masquerading router. NAT is just one of the network function which can
-be implemented ina `vdens`: potentially all the NFV action that can be implemented in a linux box, like packet screening
+be implemented in a `vdens`: potentially all the NFV action that can be implemented in a linux box, like packet screening
 and shaping. bridging, traffic prioritization, should work properly in `vdens` using exacly the same commands.
 There are just two differences:
 

--- a/tutorials/vde_vm.md
+++ b/tutorials/vde_vm.md
@@ -108,7 +108,7 @@ Create the tap interface and assign it to the user `user`.
 ```
 $ su -
 # ip tuntap add mode tap name tap0 user user
-# ip addr 10.0.0.254/24 dev tap0
+# ip addr add 10.0.0.254/24 dev tap0
 # ip link set tap0 up
 #exit
 $
@@ -143,7 +143,7 @@ UM-L can be installed from the Linux distribution:
 ```
 $ su -
 # apt-get update
-# apt-get user-mode-linux
+# apt-get install user-mode-linux
 # exit
 ```
 

--- a/tutorials/vde_vxvde.md
+++ b/tutorials/vde_vxvde.md
@@ -29,7 +29,7 @@ Cons of `vxvde`:
 
 * there is no access control to the `vxvde` virtual networks. Any user having a standard shell access on the
 hosts of the LAN (and enabled to run programs involving the use of the network) can add VDE clients to the active Local Area Clouds.
-* there is no encrytion
+* there is no encryption
 
 Note: In many scenarios these limitations are not problems. For example in Data Centers providing Virtual Machines to their
 customers (i.e. suppliers of IaaS cloud nodes), only the employees have shell access to the physical hosts and

--- a/tutorials/vdebasics.md
+++ b/tutorials/vdebasics.md
@@ -78,12 +78,12 @@ the ASCII value of the character).
 * when `vde_plug` has only one argument it uses the standard streams (`stdin`, `stdout`) to communicate, so it needs a second `vde_plug` connected
 through a dual pipe (`dpipe` command) to connect the other plugin:
 
-  `dpipe vde_plug foo://... = vde_plug bar://`
+  `dpipe vde_plug foo://... = vde_plug bar://...`
 
   ![plug.r1arg](pictures/vde_plug_1arg.png)
 
   The bidirectional stream can be processed: any tool able to support a bidirectional stream can be used. As an example we could want foo and bar to
 run on different hosts, we can use ssh to forward the stream:
 
-  `dpipe vde_plug foo://... = ssh remote.host vde_plug bar://`
+  `dpipe vde_plug foo://... = ssh remote.host vde_plug bar://...`
 


### PR DESCRIPTION
As discussed in the present day's lecture here are some patches to the tutorials found in the wiki.