### PR TITLE
Fix: added pandoc to required packets

### DIFF
--- a/archive/install_scripts/install_packets_for_v2.sh
+++ b/archive/install_scripts/install_packets_for_v2.sh
@@ -5,7 +5,7 @@ apt-get --yes install git python3 build-essential cmake make autogen \
 	libexecs-dev libmhash-dev libpam0g-dev libssl-dev netcat-openbsd netcat-traditional \
 	libfuse-dev e2fsprogs comerr-dev e2fslibs-dev xterm \
 	udhcpc x11-utils libpcap-dev libslirp-dev vim gzip \
-	vde2 vdetelweb archivemount libarchive-dev sshfs
+	vde2 vdetelweb archivemount libarchive-dev sshfs pandoc
 
 ln -sf /bin/false /bin/nologin
 echo 'kernel.unprivileged_userns_clone=1' > /etc/sysctl.d/00-local-userns.conf


### PR DESCRIPTION
On most Debian machines, the installation script for `cado` fails because `pandoc` is missing.  
To resolve this issue, I propose adding pandoc to the packets installation scripts.