### PR TITLE
fix vde-2 compilation

### DIFF
--- a/archive/install_scripts/install_v2_projects.sh
+++ b/archive/install_scripts/install_v2_projects.sh
@@ -78,7 +78,7 @@ mkdir gits
 
 install_repo https://github.com/virtualsquare/s2argv-execs.git
 install_repo https://github.com/rd235/strcase.git
-install_repo https://github.com/virtualsquare/vde-2.git -enable-experimental
+install_repo https://github.com/virtualsquare/vde-2.git -DENABLE_EXPERIMENTAL=ON
 install_repo https://github.com/rd235/vdeplug4.git
 install_repo https://github.com/virtualsquare/purelibc.git
 install_repo https://github.com/rd235/libvolatilestream.git


### PR DESCRIPTION
After the vde-2 porting to CMake (https://github.com/virtualsquare/vde-2/commit/674c8eca8f61872cc9d9f2c725fb04149e503738) the script will fail to compile vde-2 returning this error:
```
CMAKE
CMake Error: Unknown argument -enable-experimental
CMake Error: Run 'cmake --help' for all supported options.
```

I removed the flag.